### PR TITLE
Conditionally set C++ standard to 17 if not already defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.20)
 
 project(jeff-mlir DESCRIPTION "A jeff dialect in MLIR" LANGUAGES CXX C)
 
-set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
+if(NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 17)
+  set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
+endif()
 
 find_package(MLIR REQUIRED CONFIG)
 


### PR DESCRIPTION
This PR ensures that pulling in this repository will not overwrite the CXX standard if it is already set and no older than C++17.
This enables to set the CXX standard to C++20 in consuming projects.