### PR TITLE
Suppress noisy C++20 compiler warning about ambiguous reversed operators in MLIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,10 @@ include(TableGen)
 include(AddLLVM)
 include(AddMLIR)
 
-include_directories(${LLVM_INCLUDE_DIRS})
-include_directories(${MLIR_INCLUDE_DIRS})
+include_directories(SYSTEM
+  ${LLVM_INCLUDE_DIRS}
+  ${MLIR_INCLUDE_DIRS}
+)
 include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${PROJECT_BINARY_DIR}/include)
 

--- a/include/jeff/IR/JeffOps.h
+++ b/include/jeff/IR/JeffOps.h
@@ -14,17 +14,6 @@
 
 #pragma once
 
-// Suppress warnings about ambiguous reversed operators in MLIR
-// (see https://github.com/llvm/llvm-project/issues/45853)
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wambiguous-reversed-operator"
-#endif
-#include "mlir/Interfaces/InferTypeOpInterface.h"
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
-
 #include <optional>
 
 #include "llvm/ADT/StringRef.h"
@@ -35,6 +24,7 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Support/LogicalResult.h"
 


### PR DESCRIPTION
This silences a compiler warning when compiling the project in C++20 mode.
See https://github.com/llvm/llvm-project/issues/45853 for details on the issue.
Unfortunately, the suppression only really works for clang as gcc doesn't have a fine-grained exclude for this diagnostic.