### PR TITLE
Update CMake minimum version to support a range from 3.20 to 4.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.20...4.2)
 
 project(jeff-mlir DESCRIPTION "A jeff dialect in MLIR" LANGUAGES CXX C)
 


### PR DESCRIPTION
It's a best practice to indicate a range of supported CMake versions, which enables newer (CMake) policies when running on CMake versions up to the indicated upper bound.