### PR TITLE
Fix deserialization of functions

### DIFF
--- a/lib/Translation/Deserialize.cpp
+++ b/lib/Translation/Deserialize.cpp
@@ -39,7 +39,7 @@ namespace {
 struct DeserializationContext {
     llvm::DenseMap<uint32_t, mlir::Value> values;
     capnp::List<jeff::Value>::Reader jeffValues;
-    llvm::DenseMap<uint32_t, mlir::func::FuncOp> funcs;
+    llvm::DenseMap<uint16_t, mlir::func::FuncOp> funcs;
     llvm::SmallVector<std::string> strings;
 
     mlir::Value getValue(uint32_t id) {
@@ -59,7 +59,7 @@ struct DeserializationContext {
         values[id] = value;
     }
 
-    mlir::func::FuncOp getFunc(uint32_t id) {
+    mlir::func::FuncOp getFunc(uint16_t id) {
         auto it = funcs.find(id);
         if (it == funcs.end()) {
             llvm::errs() << "Function " << id << " not found\n";
@@ -68,7 +68,7 @@ struct DeserializationContext {
         return it->second;
     }
 
-    void setFunc(uint32_t id, mlir::func::FuncOp func) {
+    void setFunc(uint16_t id, mlir::func::FuncOp func) {
         if (funcs.contains(id)) {
             llvm::errs() << "Function " << id << " already exists\n";
             llvm::report_fatal_error("Function already exists");
@@ -1506,7 +1506,7 @@ void deserializeOperations(mlir::ImplicitLocOpBuilder& builder,
 }
 
 void deserializeFunction(mlir::ImplicitLocOpBuilder& builder, jeff::Function::Reader function,
-                         DeserializationContext& ctx) {
+                         uint16_t functionId, DeserializationContext& ctx) {
     ctx.values.clear();
 
     // Get function definition
@@ -1555,7 +1555,7 @@ void deserializeFunction(mlir::ImplicitLocOpBuilder& builder, jeff::Function::Re
     const auto funcName = ctx.strings[function.getName()];
     auto funcType = builder.getFunctionType(sourceTypes, targetTypes);
     auto func = mlir::func::FuncOp::create(builder, funcName, funcType);
-    ctx.setFunc(function.getName(), func);
+    ctx.setFunc(functionId, func);
 
     mlir::OpBuilder::InsertionGuard guard(builder);
     auto& entryBlock = *func.addEntryBlock();
@@ -1622,8 +1622,9 @@ mlir::OwningOpRef<mlir::ModuleOp> deserialize(mlir::MLIRContext* context, llvm::
     const auto functions = jeffModule.getFunctions();
     ctx.funcs.reserve(functions.size());
 
+    uint16_t functionId = 0;
     for (const auto function : functions) {
-        deserializeFunction(builder, function, ctx);
+        deserializeFunction(builder, function, functionId++, ctx);
     }
 
     // Set metadata

--- a/lib/Translation/Serialize.cpp
+++ b/lib/Translation/Serialize.cpp
@@ -41,7 +41,7 @@ namespace {
 struct SerializationContext {
     llvm::DenseMap<mlir::Value, uint32_t> values;
     llvm::StringMap<uint16_t> funcs;
-    llvm::StringMap<uint32_t> strings;
+    llvm::StringMap<uint16_t> strings;
 
     uint32_t getValueId(mlir::Value value) {
         auto it = values.find(value);
@@ -62,7 +62,7 @@ struct SerializationContext {
         return it->second;
     }
 
-    uint32_t getStringId(llvm::StringRef str) {
+    uint16_t getStringId(llvm::StringRef str) {
         auto it = strings.find(str);
         if (it == strings.end()) {
             llvm::errs() << "String " << str << " not found\n";
@@ -1673,7 +1673,7 @@ void writeMessage(mlir::ModuleOp module, capnp::MallocMessageBuilder& message) {
     auto stringsAttr = llvm::cast<mlir::ArrayAttr>(module->getAttr("jeff.strings"));
     const auto numStrings = stringsAttr.size();
     auto stringsBuilder = moduleBuilder.initStrings(numStrings);
-    for (auto i = 0; i < numStrings; ++i) {
+    for (int32_t i = 0; i < numStrings; ++i) {
         const auto str = llvm::cast<mlir::StringAttr>(stringsAttr[i]).getValue().str();
         ctx.strings[str] = i;
         stringsBuilder.set(i, str);

--- a/lib/Translation/Serialize.cpp
+++ b/lib/Translation/Serialize.cpp
@@ -40,7 +40,7 @@ namespace {
 
 struct SerializationContext {
     llvm::DenseMap<mlir::Value, uint32_t> values;
-    llvm::StringMap<uint32_t> funcs;
+    llvm::StringMap<uint16_t> funcs;
     llvm::StringMap<uint32_t> strings;
 
     uint32_t getValueId(mlir::Value value) {
@@ -53,7 +53,7 @@ struct SerializationContext {
         return id;
     }
 
-    uint32_t getFuncId(llvm::StringRef funcName) {
+    uint16_t getFuncId(llvm::StringRef funcName) {
         auto it = funcs.find(funcName);
         if (it == funcs.end()) {
             llvm::errs() << "Function " << funcName << " not found\n";
@@ -1613,11 +1613,11 @@ void serializeOperation(jeff::Op::Builder builder, mlir::Operation* operation,
         });
 }
 
-void serializeFunction(jeff::Function::Builder funcBuilder, mlir::func::FuncOp func,
+void serializeFunction(jeff::Function::Builder functionBuilder, mlir::func::FuncOp func,
                        SerializationContext& ctx) {
     ctx.values.clear();
 
-    auto defBuilder = funcBuilder.initDefinition();
+    auto defBuilder = functionBuilder.initDefinition();
     auto& entryBlock = func.getRegion().front();
 
     // Build body
@@ -1680,7 +1680,7 @@ void writeMessage(mlir::ModuleOp module, capnp::MallocMessageBuilder& message) {
     }
 
     // Build functions
-    uint32_t id = 0;
+    uint16_t id = 0;
     llvm::SmallVector<mlir::func::FuncOp> functions;
     for (auto func : module.getOps<mlir::func::FuncOp>()) {
         ctx.funcs[func.getSymName()] = id++;


### PR DESCRIPTION
This PR fixes the deserialization of functions by no longer relying on the index of the function name, as required by the spec: https://github.com/unitaryfoundation/jeff/blob/8bee28ef974b928f00465f316425d22548c0e7e8/impl/capnp/jeff.capnp#L1497-L1498

I came across this bug while trying to create the issue promised in https://github.com/PennyLaneAI/jeff-mlir/pull/14#issuecomment-4247181127. While the Python builder does like to mix up the order of the strings, it does not create faulty `jeff` modules.