### PR TITLE
Add version link to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,5 +38,6 @@ This release is compatible with `jeff-v0.2.0`.
 
 <!-- Version links -->
 
+[0.3.0]: https://github.com/PennyLaneAI/jeff-mlir/tree/v0.3.0
 [0.2.0]: https://github.com/PennyLaneAI/jeff-mlir/tree/v0.2.0
 [0.1.0]: https://github.com/PennyLaneAI/jeff-mlir/tree/v0.1.0


### PR DESCRIPTION
This PR adds a link to the `v0.3.0` release, after I forgot to do so in #24.