### PR TITLE
Improve error handling in `serializeToFile` and `deserializeFromFile`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,9 +22,9 @@ jobs:
   lint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Set up Clang ${{ env.CLANG_VERSION }}
         env:
           TEMP_DIR: ${{ runner.temp }}
@@ -46,15 +46,15 @@ jobs:
           echo "CC=clang-$clang_version" >> $GITHUB_ENV
           echo "CXX=clang++-$clang_version" >> $GITHUB_ENV
       - name: Set up MLIR
-        uses: munich-quantum-software/setup-mlir@97da765dfa9dc8e055611ca934fe51bcade8140c # v1.3.0
+        uses: munich-quantum-software/setup-mlir@fc08baf0a172e98008e6528d465de3b5dd99bc68 # v1.4.1
         with:
-          llvm-version: 21.1.8
+          llvm-version: 22.1.7
       - name: Configure
         run: cmake -S . -B build
       - name: Build
         run: cmake --build build
       - name: Run cpp-linter
-        uses: cpp-linter/cpp-linter-action@b6edc0625e3941baa1797f4b4326adeab6890c97 # v2.16.7
+        uses: cpp-linter/cpp-linter-action@8e85cd02c8c3fe3ae527c94b5683fe2366b144ed # v2.20.0
         id: linter
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
           echo "CC=clang-$clang_version" >> $GITHUB_ENV
           echo "CXX=clang++-$clang_version" >> $GITHUB_ENV
       - name: Set up MLIR
-        uses: munich-quantum-software/setup-mlir@fc08baf0a172e98008e6528d465de3b5dd99bc68 # v1.4.1
+        uses: munich-quantum-software/setup-mlir@3f32263ce571a8b745068980f30f188b6e800763 # v1.4.2
         with:
           llvm-version: 22.1.7
       - name: Configure

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up MLIR
         uses: munich-quantum-software/setup-mlir@fc08baf0a172e98008e6528d465de3b5dd99bc68 # v1.4.1
         with:
-          llvm-version: 22.1.7
+          llvm-version: 22.1.8
       - name: Configure
         run: cmake -S . -B build
       - name: Build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up MLIR
         uses: munich-quantum-software/setup-mlir@3f32263ce571a8b745068980f30f188b6e800763 # v1.4.2
         with:
-          llvm-version: 22.1.7
+          llvm-version: 22.1.8
       - name: Configure
         run: cmake -S . -B build
       - name: Build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up MLIR
         uses: munich-quantum-software/setup-mlir@fc08baf0a172e98008e6528d465de3b5dd99bc68 # v1.4.1
         with:
-          llvm-version: 22.1.8
+          llvm-version: 22.1.7
       - name: Configure
         run: cmake -S . -B build
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,20 +14,29 @@ concurrency:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    name: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-24.04, macos-26, windows-2025]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Set up MLIR
-        uses: munich-quantum-software/setup-mlir@97da765dfa9dc8e055611ca934fe51bcade8140c # v1.3.0
+        uses: munich-quantum-software/setup-mlir@fc08baf0a172e98008e6528d465de3b5dd99bc68 # v1.4.1
         with:
-          llvm-version: 21.1.8
+          llvm-version: 22.1.7
       - name: Configure
-        run: cmake -S . -B build
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
       - name: Build
-        run: cmake --build build
+        run: cmake --build build --config Release
       - name: Test
-        run: ctest --test-dir build --output-on-failure
+        run: ctest --build-config Release --test-dir build --output-on-failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-24.04, macos-26, windows-2025]
+        runs-on:
+          [
+            ubuntu-24.04,
+            ubuntu-24.05-arm,
+            macos-26,
+            macos-26-intel,
+            windows-2025,
+            windows-11-arm,
+          ]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up uv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Set up MLIR
-        uses: munich-quantum-software/setup-mlir@fc08baf0a172e98008e6528d465de3b5dd99bc68 # v1.4.1
+        uses: munich-quantum-software/setup-mlir@3f32263ce571a8b745068980f30f188b6e800763 # v1.4.2
         with:
           llvm-version: 22.1.7
       - name: Configure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,6 @@ jobs:
             macos-26,
             macos-26-intel,
             windows-2025,
-            windows-11-arm,
           ]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up MLIR
         uses: munich-quantum-software/setup-mlir@fc08baf0a172e98008e6528d465de3b5dd99bc68 # v1.4.1
         with:
-          llvm-version: 22.1.7
+          llvm-version: 22.1.8
       - name: Configure
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up MLIR
         uses: munich-quantum-software/setup-mlir@3f32263ce571a8b745068980f30f188b6e800763 # v1.4.2
         with:
-          llvm-version: 22.1.7
+          llvm-version: 22.1.8
       - name: Configure
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up MLIR
         uses: munich-quantum-software/setup-mlir@fc08baf0a172e98008e6528d465de3b5dd99bc68 # v1.4.1
         with:
-          llvm-version: 22.1.8
+          llvm-version: 22.1.7
       - name: Configure
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         runs-on:
           [
             ubuntu-24.04,
-            ubuntu-24.05-arm,
+            ubuntu-24.04-arm,
             macos-26,
             macos-26-intel,
             windows-2025,

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.cache
 build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This file tracks the changes to `jeff-mlir`.
 The project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+`serializeToFile()` now returns `mlir::LogicalResult` instead of `void` and
+reports a failure to open the output file through that result. Previously, it
+called `llvm::report_fatal_error()`, which aborts the process and leaves callers
+no way to handle the error. For the same reason, `deserializeFromFile()` now
+returns a null module instead of aborting when the input file cannot be read.
+
 ## [0.3.0] - 2026-07-13
 
 This release fixes the linearity of `WhileOp` (see
@@ -38,6 +46,7 @@ This release is compatible with `jeff-v0.2.0`.
 
 <!-- Version links -->
 
+[unreleased]: https://github.com/PennyLaneAI/jeff-mlir/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/PennyLaneAI/jeff-mlir/tree/v0.3.0
 [0.2.0]: https://github.com/PennyLaneAI/jeff-mlir/tree/v0.2.0
 [0.1.0]: https://github.com/PennyLaneAI/jeff-mlir/tree/v0.1.0

--- a/include/jeff/IR/JeffOps.h
+++ b/include/jeff/IR/JeffOps.h
@@ -39,6 +39,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "jeff/IR/JeffDialect.h"
+#define GET_ENUMDEF_CLASSES
 #include "jeff/IR/JeffEnums.h.inc"
 #define GET_ATTRDEF_CLASSES
 #include "jeff/IR/JeffAttributes.h.inc"

--- a/include/jeff/IR/JeffOps.h
+++ b/include/jeff/IR/JeffOps.h
@@ -39,7 +39,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "jeff/IR/JeffDialect.h"
-#define GET_ENUMDEF_CLASSES
 #include "jeff/IR/JeffEnums.h.inc"
 #define GET_ATTRDEF_CLASSES
 #include "jeff/IR/JeffAttributes.h.inc"

--- a/include/jeff/Translation/Serialize.hpp
+++ b/include/jeff/Translation/Serialize.hpp
@@ -3,6 +3,7 @@
 #include <capnp/common.h>
 #include <kj/array.h>
 #include <mlir/IR/BuiltinOps.h>
+#include <mlir/Support/LLVM.h>
 
 /**
  * @brief Serialize an MLIR module containing a jeff program into a memory buffer.
@@ -20,10 +21,11 @@ kj::Array<capnp::word> serialize(mlir::ModuleOp module);
  * @brief Serialize an MLIR module containing a jeff program into a .jeff file.
  * @param module The MLIR module to serialize.
  * @param path The path to the .jeff file.
+ * @return Success if the file was written, failure otherwise.
  *
  * @details
  * Known limitations:
  *
  * - Only one-dimensional tensors with dynamic size are supported.
  */
-void serializeToFile(mlir::ModuleOp module, llvm::StringRef path);
+mlir::LogicalResult serializeToFile(mlir::ModuleOp module, llvm::StringRef path);

--- a/lib/Conversion/JeffToNative/CMakeLists.txt
+++ b/lib/Conversion/JeffToNative/CMakeLists.txt
@@ -5,6 +5,9 @@ add_mlir_conversion_library(
     ${CONVERSION_SOURCES}
     DEPENDS
     JeffToNativeIncGen
+    MLIRJeffEnumsIncGen
+    MLIRJeffInterfacesIncGen
+    MLIRJeffOpsIncGen
     LINK_LIBS
     MLIRArithDialect
     MLIRDialect

--- a/lib/Conversion/NativeToJeff/CMakeLists.txt
+++ b/lib/Conversion/NativeToJeff/CMakeLists.txt
@@ -5,6 +5,9 @@ add_mlir_conversion_library(
     ${CONVERSION_SOURCES}
     DEPENDS
     NativeToJeffIncGen
+    MLIRJeffEnumsIncGen
+    MLIRJeffInterfacesIncGen
+    MLIRJeffOpsIncGen
     LINK_LIBS
     MLIRArithDialect
     MLIRDialect

--- a/lib/Translation/CMakeLists.txt
+++ b/lib/Translation/CMakeLists.txt
@@ -2,6 +2,10 @@ add_mlir_library(
     MLIRJeffTranslation
     Deserialize.cpp
     Serialize.cpp
+    DEPENDS
+    MLIRJeffEnumsIncGen
+    MLIRJeffInterfacesIncGen
+    MLIRJeffOpsIncGen
     LINK_LIBS
     PRIVATE
     MLIRJeff

--- a/lib/Translation/Deserialize.cpp
+++ b/lib/Translation/Deserialize.cpp
@@ -11,6 +11,7 @@
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
+#include <llvm/Support/Alignment.h>
 #include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/MemoryBuffer.h>
@@ -1562,16 +1563,24 @@ mlir::OwningOpRef<mlir::ModuleOp> deserialize(mlir::MLIRContext* context,
 
 mlir::OwningOpRef<mlir::ModuleOp> deserializeFromFile(mlir::MLIRContext* context,
                                                       llvm::StringRef path) {
-    auto file = llvm::MemoryBuffer::getFile(path);
+    // The buffer is read as an array of Cap'n Proto words, so request a buffer
+    // that is aligned accordingly.
+    auto file = llvm::MemoryBuffer::getFile(path, /*IsText=*/false,
+                                            /*RequiresNullTerminator=*/true, /*IsVolatile=*/false,
+                                            llvm::Align(alignof(capnp::word)));
     if (!file) {
-        llvm::errs() << "Failed to open file: " << path << "\n";
-        llvm::report_fatal_error("Could not open file");
+        llvm::errs() << "Failed to open " << path << ": " << file.getError().message() << "\n";
+        return {};
     }
 
     // Get jeff module from buffer
     const auto bytes = (*file)->getBuffer();
-    assert(bytes.size() % sizeof(capnp::word) == 0 &&
-           "Serialized module size must be a multiple of capnp::word size");
+    if (bytes.size() % sizeof(capnp::word) != 0) {
+        llvm::errs() << "Failed to read " << path
+                     << ": size must be a multiple of the Cap'n Proto word size\n";
+        return {};
+    }
+
     assert(reinterpret_cast<uintptr_t>(bytes.data()) % alignof(capnp::word) == 0 &&
            "Serialized module buffer must be aligned to capnp::word alignment");
     const auto words = kj::ArrayPtr(reinterpret_cast<const capnp::word*>(bytes.data()),

--- a/lib/Translation/Serialize.cpp
+++ b/lib/Translation/Serialize.cpp
@@ -17,6 +17,7 @@
 #include <llvm/ADT/StringRef.h>
 #include <llvm/ADT/TypeSwitch.h>
 #include <llvm/Support/Casting.h>
+#include <llvm/Support/Error.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/raw_ostream.h>
@@ -1546,21 +1547,25 @@ kj::Array<capnp::word> serialize(mlir::ModuleOp module) {
     return capnp::messageToFlatArray(message);
 }
 
-void serializeToFile(mlir::ModuleOp module, llvm::StringRef path) {
-    int file = 0;
-    if (llvm::sys::fs::openFileForWrite(path, file)) {
-        llvm::report_fatal_error("Could not open file");
-    }
-    auto fd = llvm::sys::fs::convertFDToNativeFile(file);
+mlir::LogicalResult serializeToFile(mlir::ModuleOp module, llvm::StringRef path) {
     capnp::MallocMessageBuilder message;
     writeMessage(module, message);
 
+    auto file = llvm::sys::fs::openNativeFileForWrite(path, llvm::sys::fs::CD_CreateAlways,
+                                                      llvm::sys::fs::OF_None);
+    if (!file) {
+        llvm::errs() << "Failed to open " << path << ": " << llvm::toString(file.takeError())
+                     << "\n";
+        return mlir::failure();
+    }
+
 #ifdef _WIN32
-    kj::AutoCloseHandle handle(fd);
+    kj::AutoCloseHandle handle(*file);
     kj::HandleOutputStream output(kj::mv(handle));
     capnp::writeMessage(output, message);
 #else
-    const kj::AutoCloseFd autoCloseFd(fd);
+    const kj::AutoCloseFd autoCloseFd(*file);
     capnp::writeMessageToFd(autoCloseFd, message);
 #endif
+    return mlir::success();
 }

--- a/lib/Translation/Serialize.cpp
+++ b/lib/Translation/Serialize.cpp
@@ -28,6 +28,7 @@
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/Types.h>
 #include <mlir/IR/Value.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cstddef>
 #include <cstdint>

--- a/unittests/Translation/test_round_trip.cpp
+++ b/unittests/Translation/test_round_trip.cpp
@@ -15,6 +15,7 @@
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/MLIRContext.h>
+#include <mlir/Support/LLVM.h>
 
 #include <algorithm>
 #include <filesystem>

--- a/unittests/Translation/test_round_trip.cpp
+++ b/unittests/Translation/test_round_trip.cpp
@@ -119,3 +119,64 @@ TEST_P(RoundTripTest, RoundTrip) {
 }
 
 INSTANTIATE_TEST_SUITE_P(, RoundTripTest, ::testing::ValuesIn(getTestCases()));
+
+TEST(SerializeToFileTest, WritesFileThatRoundTrips) {
+    mlir::DialectRegistry registry;
+    registry.insert<mlir::func::FuncDialect, mlir::jeff::JeffDialect>();
+
+    mlir::MLIRContext context(registry);
+    context.loadAllAvailableDialects();
+
+    const fs::path inputsDir = TEST_INPUTS_DIR;
+    const auto& input = inputsDir / "bell_pair.jeff";
+    auto mlirModule = deserializeFromFile(&context, input.string());
+    ASSERT_TRUE(mlirModule);
+
+    const auto output = fs::path(::testing::TempDir()) / "serialize_to_file.jeff";
+    ASSERT_TRUE(mlir::succeeded(serializeToFile(*mlirModule, output.string())));
+
+    EXPECT_EQ(readJeffFileToText(input.string()), readJeffFileToText(output.string()));
+}
+
+TEST(SerializeToFileTest, FailsForUnwritablePath) {
+    mlir::DialectRegistry registry;
+    registry.insert<mlir::func::FuncDialect, mlir::jeff::JeffDialect>();
+
+    mlir::MLIRContext context(registry);
+    context.loadAllAvailableDialects();
+
+    const fs::path inputsDir = TEST_INPUTS_DIR;
+    auto mlirModule = deserializeFromFile(&context, (inputsDir / "bell_pair.jeff").string());
+    ASSERT_TRUE(mlirModule);
+
+    const auto output = fs::path(::testing::TempDir()) / "missing" / "serialize_to_file.jeff";
+    EXPECT_TRUE(mlir::failed(serializeToFile(*mlirModule, output.string())));
+}
+
+TEST(DeserializeFromFileTest, ReturnsNullForMissingFile) {
+    mlir::DialectRegistry registry;
+    registry.insert<mlir::func::FuncDialect, mlir::jeff::JeffDialect>();
+
+    mlir::MLIRContext context(registry);
+    context.loadAllAvailableDialects();
+
+    const auto input = fs::path(::testing::TempDir()) / "missing" / "does_not_exist.jeff";
+    EXPECT_FALSE(deserializeFromFile(&context, input.string()));
+}
+
+TEST(DeserializeFromFileTest, ReturnsNullForTruncatedFile) {
+    mlir::DialectRegistry registry;
+    registry.insert<mlir::func::FuncDialect, mlir::jeff::JeffDialect>();
+
+    mlir::MLIRContext context(registry);
+    context.loadAllAvailableDialects();
+
+    // Drop a single byte so that the size is no longer a multiple of the word size.
+    const fs::path inputsDir = TEST_INPUTS_DIR;
+    const auto input = inputsDir / "bell_pair.jeff";
+    const auto truncated = fs::path(::testing::TempDir()) / "truncated.jeff";
+    fs::copy_file(input, truncated, fs::copy_options::overwrite_existing);
+    fs::resize_file(truncated, fs::file_size(truncated) - 1);
+
+    EXPECT_FALSE(deserializeFromFile(&context, truncated.string()));
+}


### PR DESCRIPTION
This PR improves the error handling in `serializeToFile` and `deserializeFromFile`. `serializeToFile()` now returns `mlir::LogicalResult` instead of `void` and reports a failure to open the output file through that result. Previously, it called `llvm::report_fatal_error()`, which aborts the process and leaves callers no way to handle the error. For the same reason, `deserializeFromFile()` now returns a null module instead of aborting when the input file cannot be read.

Furthermore, this PR updates the CI to also run tests on macOS and Windows.