### PR TITLE
Add `prek` action

### DIFF
--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   prek:
     runs-on: ubuntu-latest

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -1,0 +1,14 @@
+name: prek checks
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  merge_group:
+
+jobs:
+  prek:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: j178/prek-action@5337cb91e0fa35a7ff31b9ca345126d8bbbcdf16 # v2.0.6

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,4 @@
+preview = true
+fix = true
+unsafe-fixes = true
+show-fixes = true

--- a/unittests/generate_test_cases.py
+++ b/unittests/generate_test_cases.py
@@ -7,28 +7,29 @@
 # ]
 # ///
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
+
 from jeff import (
-    JeffRegion,
-    JeffModule,
+    FloatArrayType,
+    FloatType,
+    ForSCF,
+    FunctionDef,
+    IntArrayType,
     IntType,
+    JeffModule,
     JeffOp,
+    JeffRegion,
     JeffValue,
     QubitType,
-    FunctionDef,
-    qubit_alloc,
-    qubit_free,
-    FloatType,
-    quantum_gate,
-    ForSCF,
-    pauli_rotation,
-    switch_case,
     QuregType,
     WhileSCF,
-    IntArrayType,
-    FloatArrayType,
+    pauli_rotation,
+    quantum_gate,
+    qubit_alloc,
+    qubit_free,
     schema,
+    switch_case,
 )
 
 INPUTS_DIR = Path(__file__).parent / "inputs"


### PR DESCRIPTION
This PR adds a workflow that runs [j178/prek-action](https://github.com/j178/prek-action) to ensure that all pre-commit hooks are happy. 