### PR TITLE
Add CMake presets

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,16 +50,16 @@ jobs:
         with:
           llvm-version: 22.1.8
       - name: Configure
-        run: cmake -S . -B build
+        run: cmake --preset lint
       - name: Build
-        run: cmake --build build
+        run: cmake --build --preset lint
       - name: Run cpp-linter
         uses: cpp-linter/cpp-linter-action@8e85cd02c8c3fe3ae527c94b5683fe2366b144ed # v2.20.0
         id: linter
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          database: build
+          database: build/lint
           files-changed-only: true
           ignore: "build|include"
           step-summary: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,14 +25,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on:
-          [
-            ubuntu-24.04,
-            ubuntu-24.04-arm,
-            macos-26,
-            macos-26-intel,
-            windows-2025,
-          ]
+        include:
+          - runs-on: ubuntu-24.04
+            preset: release
+          - runs-on: ubuntu-24.04-arm
+            preset: release
+          - runs-on: macos-26
+            preset: release
+          - runs-on: macos-26-intel
+            preset: release
+          - runs-on: windows-2025
+            preset: release-windows
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up uv
@@ -42,8 +45,8 @@ jobs:
         with:
           llvm-version: 22.1.8
       - name: Configure
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+        run: cmake --preset ${{ matrix.preset }}
       - name: Build
-        run: cmake --build build --config Release
+        run: cmake --build --preset ${{ matrix.preset }}
       - name: Test
-        run: ctest --build-config Release --test-dir build --output-on-failure
+        run: ctest --preset ${{ matrix.preset }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .cache
+.env
 build

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,135 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "MLIR_DIR": "$env{MLIR_DIR}"
+      }
+    },
+    {
+      "name": "base-unix",
+      "hidden": true,
+      "inherits": "base",
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": ["Linux", "Darwin"]
+      },
+      "description": "Default configuration for Linux and macOS builds. Uses the Ninja generator",
+      "generator": "Ninja"
+    },
+    {
+      "name": "base-windows",
+      "hidden": true,
+      "inherits": "base",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "description": "Default configuration for Windows builds. Uses the default generator"
+    },
+    {
+      "name": "debug",
+      "inherits": "base-unix",
+      "displayName": "Debug config",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "LLVM_ENABLE_ASSERTIONS": "ON"
+      }
+    },
+    {
+      "name": "release",
+      "inherits": "base-unix",
+      "displayName": "Release config",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "lint",
+      "inherits": "base-unix",
+      "displayName": "Lint config",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "BUILD_JEFF_MLIR_TESTS": "ON",
+        "BUILD_JEFF_MLIR_TRANSLATION": "ON",
+        "BUILD_JEFF_OPT": "ON"
+      }
+    },
+    {
+      "name": "debug-windows",
+      "inherits": "base-windows",
+      "displayName": "Windows Debug config",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "LLVM_ENABLE_ASSERTIONS": "ON"
+      }
+    },
+    {
+      "name": "release-windows",
+      "inherits": "base-windows",
+      "displayName": "Windows Release config",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "release",
+      "configurePreset": "release"
+    },
+    {
+      "name": "lint",
+      "configurePreset": "lint"
+    },
+    {
+      "name": "debug-windows",
+      "configurePreset": "debug-windows",
+      "configuration": "Debug"
+    },
+    {
+      "name": "release-windows",
+      "configurePreset": "release-windows",
+      "configuration": "Release"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "output": { "outputOnFailure": true },
+      "execution": { "timeout": 600 }
+    },
+    {
+      "name": "debug",
+      "inherits": "base",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "release",
+      "inherits": "base",
+      "configurePreset": "release"
+    },
+    {
+      "name": "debug-windows",
+      "inherits": "base",
+      "configurePreset": "debug-windows",
+      "configuration": "Debug"
+    },
+    {
+      "name": "release-windows",
+      "inherits": "base",
+      "configurePreset": "release-windows",
+      "configuration": "Release"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -68,18 +68,24 @@ Finally, you can point the `MLIR_DIR` variable to
 </details>
 <br>
 
-From here, we can build the `jeff` dialect simply via:
+From here, we can build the `jeff` dialect via the provided CMake presets:
 
 ```sh
-cmake -Bbuild -S. -GNinja && cmake --build build
+cmake --preset release && cmake --build --preset release
 ```
 
-If CMake can't find the MLIR build, it can be specified via `-DMLIR_DIR=...`
-during the config step, which must point to the cmake files in the build or
-installation directory, for example `/path/to/installation/lib/cmake/mlir`.
+The available presets are `debug` and `release` on Linux and macOS, and
+`debug-windows` and `release-windows` on Windows. Each preset builds into its
+own directory under `./build/<preset>`. The tests can be run with
+`ctest --preset <preset>`.
+
+If CMake can't find the MLIR build, it can be specified via the `MLIR_DIR`
+environment variable, which the presets pick up, or via `-DMLIR_DIR=...` during
+the config step. It must point to the cmake files in the build or installation
+directory, for example `/path/to/installation/lib/cmake/mlir`.
 
 The `jeff-opt` tool will be located in the build directory under
-`./build/lib/opt/jeff-opt`.
+`./build/<preset>/lib/opt/jeff-opt`.
 
 TODO: Add instructions for setting up the dialect as an MLIR plugin.
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

This PR adds a `CMakePresets.json` and updates the CI to use it.

The presets are:

- `debug` and `release` for Linux and macOS, using the Ninja generator.
- `lint` for the compilation database used by `cpp-linter`. It is a `Debug` configuration that explicitly enables `BUILD_JEFF_MLIR_TESTS`, `BUILD_JEFF_MLIR_TRANSLATION`, and `BUILD_JEFF_OPT` so that all sources end up in the database.
- `debug-windows` and `release-windows` for Windows, using the default generator.

Each preset builds into its own directory under `build/<preset>`. `MLIR_DIR` is picked up from the environment, which is what [`setup-mlir`](https://github.com/munich-quantum-software/setup-mlir) sets in CI. The `Lint` and `Test` workflows now configure, build, and test via these presets.

The build instructions in the README have been updated accordingly.
