### PR TITLE
Scope the generated Cap'n Proto source to the translation library

### DIFF
--- a/lib/Translation/CMakeLists.txt
+++ b/lib/Translation/CMakeLists.txt
@@ -20,4 +20,4 @@ target_include_directories(
                                ${jeff_BINARY_DIR}/impl/cpp/src/capnp
 )
 
-target_sources(MLIRJeffTranslation PUBLIC ${jeff_SOURCE_DIR}/impl/cpp/src/capnp/jeff.capnp.c++)
+target_sources(MLIRJeffTranslation PRIVATE ${jeff_SOURCE_DIR}/impl/cpp/src/capnp/jeff.capnp.c++)


### PR DESCRIPTION
🤖 *AI text below* 🤖

`MLIRJeffTranslation` declared the generated Cap'n Proto source as a public one, so the source was compiled into the library and into every consumer as well. A consumer that is itself a static library then carried the same 68 symbols as an executable linking above it, and the link failed with duplicate symbol errors.

Declaring the source private compiles it into `MLIRJeffTranslation` alone. Consumers get the symbols by linking the library, which is what the public include directories and the public `CapnProto::capnp` dependency already assume.

Found while adding a benchmark generator to MQT Core, where a static library and an executable above it both linked the translation library.
