### PR TITLE
Use published version of `jeff-format`

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -3,7 +3,7 @@ find_program(UV_EXECUTABLE uv REQUIRED)
 # Generate test cases
 add_test(
     NAME generate_test_cases
-    COMMAND ${UV_EXECUTABLE} run python ${CMAKE_SOURCE_DIR}/unittests/generate_test_cases.py
+    COMMAND ${UV_EXECUTABLE} run --script ${CMAKE_SOURCE_DIR}/unittests/generate_test_cases.py
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 set_tests_properties(generate_test_cases PROPERTIES FIXTURES_SETUP generate_test_cases_success)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,12 +1,17 @@
 find_program(UV_EXECUTABLE uv REQUIRED)
 
-# Generate test cases
-add_test(
-    NAME generate_test_cases
-    COMMAND ${UV_EXECUTABLE} run --script ${CMAKE_SOURCE_DIR}/unittests/generate_test_cases.py
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+# Generate test cases before the test executables are built so that the tests reading them can be
+# discovered
+set(generate_test_cases_stamp "${CMAKE_CURRENT_BINARY_DIR}/generate_test_cases.stamp")
+add_custom_command(
+    OUTPUT ${generate_test_cases_stamp}
+    COMMAND ${UV_EXECUTABLE} run --script ${CMAKE_CURRENT_SOURCE_DIR}/generate_test_cases.py
+    COMMAND ${CMAKE_COMMAND} -E touch ${generate_test_cases_stamp}
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/generate_test_cases.py
+    COMMENT "Generating test cases"
+    VERBATIM
 )
-set_tests_properties(generate_test_cases PROPERTIES FIXTURES_SETUP generate_test_cases_success)
+add_custom_target(generate_test_cases DEPENDS ${generate_test_cases_stamp})
 
 add_subdirectory(Conversion)
 add_subdirectory(IR)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,35 +1,12 @@
 find_program(UV_EXECUTABLE uv REQUIRED)
 
-# Create a virtual environment
-add_test(
-    NAME uv_venv
-    COMMAND ${UV_EXECUTABLE} venv --allow-existing
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-)
-set_tests_properties(uv_venv PROPERTIES FIXTURES_SETUP uv_venv_success)
-
-# Install jeff-format
-add_test(
-    NAME uv_pip_install_jeff_format
-    COMMAND ${UV_EXECUTABLE} pip install
-            "git+https://github.com/unitaryfoundation/jeff.git@jeff-v0.3.0#subdirectory=impl/py"
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-)
-set_tests_properties(
-    uv_pip_install_jeff_format PROPERTIES FIXTURES_SETUP uv_pip_install_jeff_format_success
-                                          FIXTURES_REQUIRED uv_venv_success
-)
-
 # Generate test cases
 add_test(
     NAME generate_test_cases
     COMMAND ${UV_EXECUTABLE} run python ${CMAKE_SOURCE_DIR}/unittests/generate_test_cases.py
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
-set_tests_properties(
-    generate_test_cases PROPERTIES FIXTURES_REQUIRED uv_pip_install_jeff_format_success
-                                   FIXTURES_SETUP generate_test_cases_success
-)
+set_tests_properties(generate_test_cases PROPERTIES FIXTURES_SETUP generate_test_cases_success)
 
 add_subdirectory(Conversion)
 add_subdirectory(IR)

--- a/unittests/Conversion/CMakeLists.txt
+++ b/unittests/Conversion/CMakeLists.txt
@@ -8,6 +8,15 @@ if(NOT TARGET ${test_name})
 
     add_executable(${test_name} test_native_round_trip.cpp)
 
+    add_dependencies(${test_name} generate_test_cases)
+
+    # Relink when the test cases change so that they are discovered again
+    set_property(
+        TARGET ${test_name}
+        APPEND
+        PROPERTY LINK_DEPENDS ${generate_test_cases_stamp}
+    )
+
     target_link_libraries(
         ${test_name} PRIVATE GTest::gtest_main MLIRJeff MLIRJeffToNative MLIRJeffTranslation
                              MLIRNativeToJeff
@@ -19,7 +28,5 @@ if(NOT TARGET ${test_name})
 
     set_target_properties(${test_name} PROPERTIES FOLDER unittests)
 
-    gtest_discover_tests(
-        ${test_name} DISCOVERY_TIMEOUT 60 PROPERTIES FIXTURES_REQUIRED generate_test_cases_success
-    )
+    gtest_discover_tests(${test_name} DISCOVERY_TIMEOUT 60)
 endif()

--- a/unittests/Translation/CMakeLists.txt
+++ b/unittests/Translation/CMakeLists.txt
@@ -8,6 +8,15 @@ if(NOT TARGET ${test_name})
 
     add_executable(${test_name} test_round_trip.cpp)
 
+    add_dependencies(${test_name} generate_test_cases)
+
+    # Relink when the test cases change so that they are discovered again
+    set_property(
+        TARGET ${test_name}
+        APPEND
+        PROPERTY LINK_DEPENDS ${generate_test_cases_stamp}
+    )
+
     target_link_libraries(${test_name} PRIVATE GTest::gtest_main MLIRJeff MLIRJeffTranslation)
 
     target_compile_definitions(
@@ -16,7 +25,5 @@ if(NOT TARGET ${test_name})
 
     set_target_properties(${test_name} PROPERTIES FOLDER unittests)
 
-    gtest_discover_tests(
-        ${test_name} DISCOVERY_TIMEOUT 60 PROPERTIES FIXTURES_REQUIRED generate_test_cases_success
-    )
+    gtest_discover_tests(${test_name} DISCOVERY_TIMEOUT 60)
 endif()

--- a/unittests/generate_test_cases.py
+++ b/unittests/generate_test_cases.py
@@ -3,7 +3,7 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#   "jeff-format",
+#   "jeff-format~=0.1.0",
 # ]
 # ///
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

The test case generation script now depends on the published `jeff-format~=0.1.0` from PyPI instead of a git tag of the `jeff` repository. `uv run --script` resolves the dependency from the script's inline metadata, so the CMake test fixtures that created a virtual environment and installed `jeff-format` into it are no longer needed and have been removed.

Generating the test cases is now a build step rather than a test. The round-trip suites are parameterized over the files in `unittests/inputs`, which they scan at startup, but `gtest_discover_tests` enumerates them at build time, before the generating test would have run. On a fresh checkout both suites were therefore discovered as empty, and CI silently ran 51 tests instead of 257. Generating the files before the test executables are built fixes this and lets the generating test and its fixtures go away.
